### PR TITLE
fix: 修正青钢标记问题

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -5281,7 +5281,7 @@ LuaSheque = sgs.CreateTriggerSkill {
             if use.from and use.from:hasFlag(self:objectName()) and use.card:isKindOf('Slash') then
                 room:broadcastSkillInvoke(self:objectName())
                 for _, p in sgs.qlist(use.to) do
-                    p:addQinggangTag(use.card)
+                    rinsan.addQinggangTag(p, use.card)
                 end
             end
         end
@@ -8808,7 +8808,7 @@ LuaChongjianQinggang = sgs.CreateTriggerSkill {
         local use = data:toCardUse()
         if use.from and use.card and use.card:isKindOf('Slash') and use.card:getSkillName() == 'LuaChongjian' then
             for _, p in sgs.qlist(use.to) do
-                p:addQinggangTag(use.card)
+                rinsan.addQinggangTag(p, use.card)
             end
         end
     end,

--- a/extensions/GroupFriendPackage.lua
+++ b/extensions/GroupFriendPackage.lua
@@ -712,7 +712,7 @@ LuaTuci = sgs.CreateTriggerSkill {
                         break
                     end
                     if p:isAlive() and p:distanceTo(player) < player:getAttackRange() + player:getMark('@LuaJing') then
-                        p:addQinggangTag(use.card)
+                        rinsan.addQinggangTag(p, use.card)
                     end
                 end
             end

--- a/lua/QSanguoshaLuaFunction.lua
+++ b/lua/QSanguoshaLuaFunction.lua
@@ -1096,8 +1096,21 @@ function getDinghanCardsTable(player)
     return dinghan_str:split('|')
 end
 
+-- 封装方法用于设置定汉记录牌名
 function setDinghanCardsTable(player, dinghan_cards)
     player:setTag('LuaDinghanCards', sgs.QVariant(table.concat(dinghan_cards, '|')))
+end
+
+-- 封装方法用于添加青钢标记
+function addQinggangTag(victim, card)
+    -- 日神杀使用迫真 QStringList 来存储青钢标记牌名
+    -- 因此需要先判断是否已经存在，如果存在就不要再加
+    -- 在【杀】结束之后，将会自动清除青钢标记
+    local qinggang = victim:getTag('Qinggang'):toStringList()
+    if qinggang:contains(card:toString()) then
+        return
+    end
+    victim:addQinggangTag(card)
 end
 
 -- CardType 参数，用于 getCardMostProbably 方法


### PR DESCRIPTION
## 拉取请求简述
修正因多余添加的青钢标记导致的防具失效问题

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #566 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
