### PR TITLE
fix: 修正【冲坚】等多卡牌选择问题

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -999,10 +999,11 @@ LuaPojun = sgs.CreateTriggerSkill {
                     if discard_n > 0 then
                         local orig_places = {}
                         local cards = sgs.IntList()
+                        room:setTag('LuaFakeMove', sgs.QVariant(true))
                         room:setPlayerFlag(t, 'xuanhuo_InTempMoving')
                         for i = 0, discard_n - 1, 1 do
                             local id = room:askForCardChosen(player, t, 'he', self:objectName(), false,
-                                sgs.Card_MethodNone)
+                                sgs.Card_MethodNone, cards)
                             local place = room:getCardPlace(id)
                             orig_places[i] = place
                             cards:append(id)
@@ -1012,6 +1013,7 @@ LuaPojun = sgs.CreateTriggerSkill {
                             room:moveCardTo(sgs.Sanguosha:getCard(cards:at(i)), t, orig_places[i], false)
                         end
                         room:setPlayerFlag(t, '-xuanhuo_InTempMoving')
+                        room:setTag('LuaFakeMove', sgs.QVariant(false))
                         local dummy = sgs.Sanguosha:cloneCard('slash', sgs.Card_NoSuit, 0)
                         dummy:addSubcards(cards)
                         t:addToPile('LuaPojun', dummy, false)
@@ -8795,8 +8797,9 @@ LuaChongjian = sgs.CreateTriggerSkill {
             local orig_places = {}
             local cards = sgs.IntList()
             room:setPlayerFlag(victim, 'xuanhuo_InTempMoving')
+            room:setTag('LuaFakeMove', sgs.QVariant(true))
             for i = 0, x - 1, 1 do
-                local id = room:askForCardChosen(player, victim, 'e', self:objectName(), false, sgs.Card_MethodNone)
+                local id = room:askForCardChosen(player, victim, 'e', self:objectName(), false, sgs.Card_MethodNone, cards)
                 local place = room:getCardPlace(id)
                 orig_places[i] = place
                 cards:append(id)
@@ -8806,6 +8809,7 @@ LuaChongjian = sgs.CreateTriggerSkill {
                 room:moveCardTo(sgs.Sanguosha:getCard(cards:at(i)), victim, orig_places[i], false)
             end
             room:setPlayerFlag(victim, '-xuanhuo_InTempMoving')
+            room:setTag('LuaFakeMove', sgs.QVariant(false))
             local dummy = sgs.Sanguosha:cloneCard('slash', sgs.Card_NoSuit, 0)
             dummy:addSubcards(cards)
             room:obtainCard(player, dummy, false)


### PR DESCRIPTION
## 拉取请求简述
修正多卡牌选择时造成的重复结算问题，例如【白银狮子】

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #583 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
