### PR TITLE
fix: 修正有护甲状态下直接受伤害濒死的显示信息

### DIFF
--- a/extensions/ShieldPackage.lua
+++ b/extensions/ShieldPackage.lua
@@ -81,7 +81,6 @@ LuaShield = sgs.CreateTriggerSkill {
             damage.to:setTag('ShieldLostCount', sgs.QVariant(math.min(damage.damage, rinsan.getShieldCount(damage.to))))
         end
 
-        room:setPlayerProperty(damage.to, 'hp', sgs.QVariant(newHp))
         rinsan.decreaseShield(damage.to, damage.damage)
 
         -- 手动播放音效和动画
@@ -89,20 +88,20 @@ LuaShield = sgs.CreateTriggerSkill {
             local delta = damage.damage > 3 and 3 or damage.damage
             sgs.Sanguosha:playSystemAudioEffect(string.format('injure%d', delta), true)
         end
-
         room:setEmotion(damage.to, 'damage')
+
         if damage.nature == sgs.DamageStruct_Fire then
             room:doAnimate(rinsan.ANIMATE_FIRE, damage.to:objectName())
         elseif damage.nature == sgs.DamageStruct_Thunder then
             room:doAnimate(rinsan.ANIMATE_LIGHTING, damage.to:objectName())
         end
-
+        
         rinsan.sendLogMessage(room, '#GetHp', {
             ['from'] = damage.to,
-            ['arg'] = damage.to:getHp(),
+            ['arg'] = newHp,
             ['arg2'] = damage.to:getMaxHp()
         })
-
+        room:setPlayerProperty(damage.to, 'hp', sgs.QVariant(newHp))
         return true
     end,
     can_trigger = globalTrigger


### PR DESCRIPTION
## 拉取请求简述
修正在有甲情况下直接被砍到濒死的表现，不在死后播放动画

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
