### PR TITLE
fix: 调整界李儒【灭计】弃牌逻辑

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -2854,8 +2854,10 @@ LuaMiejiCard = sgs.CreateSkillCard {
     name = 'LuaMiejiCard',
     will_throw = false,
     filter = function(self, selected, to_select)
-        return rinsan.checkFilter(selected, to_select, rinsan.EQUAL, 0) and
-                   rinsan.canDiscard(to_select, to_select, 'he')
+        if rinsan.checkFilter(selected, to_select, rinsan.EQUAL, 0) then
+            return rinsan.canDiscard(to_select, to_select, 'he')
+        end
+        return false
     end,
     on_use = function(self, room, source, targets)
         local target = targets[1]

--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -2854,20 +2854,21 @@ LuaMiejiCard = sgs.CreateSkillCard {
     name = 'LuaMiejiCard',
     will_throw = false,
     filter = function(self, selected, to_select)
-        return rinsan.checkFilter(selected, to_select, rinsan.EQUAL, 0) and not to_select:isNude()
+        return rinsan.checkFilter(selected, to_select, rinsan.EQUAL, 0) and
+                   rinsan.canDiscard(to_select, to_select, 'he')
     end,
     on_use = function(self, room, source, targets)
         local target = targets[1]
 
         room:broadcastSkillInvoke('LuaMieji')
         local reason = sgs.CardMoveReason(sgs.CardMoveReason_S_REASON_PUT, source:objectName(), '', 'LuaMieji', '')
-        room:moveCardTo(sgs.Sanguosha:getCard(self:getSubcards():first()), source, nil, sgs.Player_DrawPile, reason,
-            true)
+        local miejiCard = sgs.Sanguosha:getCard(self:getSubcards():first())
+        room:moveCardTo(miejiCard, source, nil, sgs.Player_DrawPile, reason, true)
         local cards = target:getCards('he')
         local cardsCopy = cards
 
         for _, c in sgs.qlist(cardsCopy) do
-            if target:isJilei(c) then
+            if target:isCardLimited(c, sgs.Card_MethodDiscard) then
                 cards:removeOne(c)
             end
         end
@@ -2878,43 +2879,43 @@ LuaMiejiCard = sgs.CreateSkillCard {
 
         local pattern = '..!'
         local nonTrickNum = 0
-        local trickExists = false
         for _, c in sgs.qlist(cards) do
-            if c:isKindOf('TrickCard') then
-                trickExists = true
-            else
+            if not c:isKindOf('TrickCard') then
                 nonTrickNum = nonTrickNum + 1
             end
         end
 
-        if nonTrickNum < 2 and trickExists then
-            pattern = 'TrickCard!'
-        end
-
         local card = room:askForCard(target, pattern, '@LuaMiejiDiscard', sgs.QVariant(), sgs.Card_MethodNone)
-        if card == nil then
-            -- 随机抽卡
-            if nonTrickNum < 2 and trickExists then
-                cardsCopy = cards
-                for _, c in sgs.qlist(cardsCopy) do
-                    if not c:isKindOf('TrickCard') then
-                        cards:removeOne(c)
-                    end
+        if not card then
+            card = cards:at(rinsan.random(0, cardsCopy:length() - 1))
+        end
+        if not card then
+            return false
+        end
+        if card:isKindOf('TrickCard') then
+            room:obtainCard(source, card)
+        else
+            room:throwCard(card, target)
+            if nonTrickNum <= 1 then
+                return false
+            end
+            pattern = '^TrickCard!'
+            local maybeCards = {}
+            for _, c in sgs.qlist(target:getCards('he')) do
+                if not target:isCardLimited(c, sgs.Card_MethodDiscard) and not c:isKindOf('TrickCard') then
+                    table.insert(maybeCards, c)
                 end
             end
-            card = cards:at(rinsan.random(0, cards:length() - 1))
-        end
-        if card then
-            if card:isKindOf('TrickCard') then
-                room:obtainCard(source, card)
-                return
-            else
+            if #maybeCards <= 0 then
+                return false
+            end
+            card = room:askForCard(target, pattern, '@LuaMiejiDiscardNonTrick', sgs.QVariant(), sgs.Card_MethodNone)
+            if not card or card:isKindOf('TrickCard') then
+                card =  maybeCards[rinsan.random(1, #maybeCards)]
+            end
+            if card then
                 room:throwCard(card, target)
             end
-        end
-
-        if target:getCardCount(true) > 0 then
-            room:askForDiscard(target, 'LuaMieji', 1, 1, false, true, '@LuaMiejiDiscardNonTrick', '^TrickCard')
         end
     end,
 }

--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -7172,13 +7172,17 @@ LuaMiaojianVS = sgs.CreateViewAsSkill {
 
 LuaMiaojian = sgs.CreateTriggerSkill {
     name = 'LuaMiaojian',
-    events = {sgs.CardUsed, sgs.SlashMissed},
+    events = {sgs.CardUsed, sgs.SlashMissed, sgs.EventPhaseEnd},
     view_as_skill = LuaMiaojianVS,
     on_trigger = function(self, event, player, data, room)
         if event == sgs.CardUsed then
             local use = data:toCardUse()
             if use.card and use.card:getSkillName() == self:objectName() then
                 room:setPlayerFlag(player, 'LuaMiaojianUsed')
+            end
+        elseif event == sgs.EventPhaseEnd then
+            if player:getPhase() == sgs.Player_Play then
+                room:setPlayerFlag(player, '-LuaMiaojianUsed')
             end
         else
             local effect = data:toSlashEffect()

--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -2911,7 +2911,7 @@ LuaMiejiCard = sgs.CreateSkillCard {
             end
             card = room:askForCard(target, pattern, '@LuaMiejiDiscardNonTrick', sgs.QVariant(), sgs.Card_MethodNone)
             if not card or card:isKindOf('TrickCard') then
-                card =  maybeCards[rinsan.random(1, #maybeCards)]
+                card = maybeCards[rinsan.random(1, #maybeCards)]
             end
             if card then
                 room:throwCard(card, target)

--- a/lua/ai/ExpansionPackage-ai.lua
+++ b/lua/ai/ExpansionPackage-ai.lua
@@ -6,46 +6,9 @@ local rinsan = require('QSanguoshaLuaFunction')
 -- 漫卷效果技能组
 local LuaManjuanEffectSkills = {'manjuan', 'zishu', 'LuaZishu'}
 
+-- 玩家是否有漫卷效果（漫卷、自书等）
 function playerHasManjuanEffect(player)
     return player:hasSkills(table.concat(LuaManjuanEffectSkills, '|'))
-end
-
--- 灭计弃牌
-sgs.ai_skill_discard['LuaMieji'] = function(self, discard_num, min_num, optional, include_equip)
-    min_num = min_num or discard_num
-    local exchange = self.player:hasFlag('Global_AIDiscardExchanging')
-    self:assignKeep(true)
-
-    local cards = self.player:getCards('he')
-    cards = sgs.QList2Table(cards)
-    self:sortByKeepValue(cards)
-    local to_discard, temp = {}, {}
-
-    local least = min_num
-    if discard_num - min_num > 1 then
-        least = discard_num - 1
-    end
-    for _, card in ipairs(cards) do
-        if exchange or not self.player:isJilei(card) and not card:isKindOf('TrickCard') then
-            if self:getKeepValue(card) >= 4.1 then
-                table.insert(temp, card:getEffectiveId())
-            else
-                table.insert(to_discard, card:getEffectiveId())
-            end
-        end
-        if (self.player:hasSkill('qinyin') and #to_discard >= least) or #to_discard >= discard_num then
-            break
-        end
-    end
-    if #to_discard < discard_num then
-        for _, id in ipairs(temp) do
-            table.insert(to_discard, id)
-            if (self.player:hasSkill('qinyin') and #to_discard >= least) or #to_discard >= discard_num then
-                break
-            end
-        end
-    end
-    return to_discard
 end
 
 -- 节钺


### PR DESCRIPTION
## 拉取请求简述
调整界李儒【灭计】弃牌逻辑，只有一张非基本牌时弃置后不需要继续询问

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
