### PR TITLE
fix: 修正斗地主初始摸牌触发武将技能问题

### DIFF
--- a/extensions/LandlordsPackage.lua
+++ b/extensions/LandlordsPackage.lua
@@ -138,12 +138,14 @@ LuaDizhu = sgs.CreateTriggerSkill {
             room:getThread():trigger(sgs.GameStart, room, p)
 
             -- 统一在这里进行初始牌的摸取，避免提前摸牌导致一些问题
+            room:setTag('FirstRound', sgs.QVariant(true))
             local draw_data = sgs.QVariant(4)
             room:getThread():trigger(sgs.DrawInitialCards, room, p, draw_data)
             local to_draw = draw_data:toInt()
             if to_draw > 0 then
                 p:drawCards(to_draw, self:objectName())
             end
+            room:setTag('FirstRound', sgs.QVariant(false))
         end
 
         -- 手气卡


### PR DESCRIPTION
## 拉取请求简述
修正斗地主初始摸牌时会触发武将技能的问题，例如步骘【弘德】

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
