### PR TITLE
fix: 文鸯【椎锋】失效期限修正

### DIFF
--- a/extensions/LayingPlansCouragePackage.lua
+++ b/extensions/LayingPlansCouragePackage.lua
@@ -423,7 +423,7 @@ LuaChuifengVS = sgs.CreateZeroCardViewAsSkill {
         if player:getKingdom() ~= 'wei' then
             return false
         end
-        return player:usedTimes('#LuaChuifengCard') < 2 and (not player:hasFlag('LuaChuifengSelfDamaged'))
+        return player:usedTimes('#LuaChuifengCard') < 2 and player:getMark('LuaChuifengSelfDamaged_biu') == 0
     end,
 }
 
@@ -434,9 +434,13 @@ LuaChuifeng = sgs.CreateTriggerSkill {
     on_trigger = function(self, event, player, data, room)
         local damage = data:toDamage()
         if damage.card and damage.card:getSkillName() == self:objectName() then
-            room:sendCompulsoryTriggerLog(player, self:objectName())
+            rinsan.sendLogMessage(room, '#LuaChuifeng', {
+                ['from'] = player,
+                ['arg'] = self:objectName(),
+                ['card_str'] = damage.card:toString(),
+            })
             room:broadcastSkillInvoke(self:objectName())
-            room:setPlayerFlag(player, 'LuaChuifengSelfDamaged')
+            room:addPlayerMark(player, 'LuaChuifengSelfDamaged_biu')
             return true
         end
         return false

--- a/lang/zh_CN/Package/LayingPlansCouragePackage.lua
+++ b/lang/zh_CN/Package/LayingPlansCouragePackage.lua
@@ -42,6 +42,7 @@ return {
     ['luachuifeng'] = '椎锋',
     [':LuaChuifeng'] = '<font color="#547998"><b>魏势力技</b></font>，<font color="green"><b>出牌阶段限两次</b></font>，你可以失去一点体力，视为使用一张【决斗】。\
     当你受到此【决斗】的伤害时，你防止此伤害，然后此技能于此阶段内失效',
+    ['#LuaChuifeng'] = '%from 的“%arg”被触发，防止了 %card 带来的伤害',
     ['LuaChongjian'] = '冲坚',
     ['luachongjian'] = '冲坚',
     [':LuaChongjian'] = '<font color="#4DB873"><b>吴势力技</b></font>，你可以将一张装备牌当【酒】或无距离限制且无视目标防具的【杀】使用。\


### PR DESCRIPTION
## 拉取请求简述
1. 修正【椎锋】受伤失效期限不正确的问题

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
