### PR TITLE
fix: 调整【合击】目标不能为自己

### DIFF
--- a/extensions/LayingPlansSincerityPackage.lua
+++ b/extensions/LayingPlansSincerityPackage.lua
@@ -96,7 +96,9 @@ LuaHeji = sgs.CreateTriggerSkill {
             end
             local wujings = room:findPlayersBySkillName(self:objectName())
             for _, wujing in sgs.qlist(wujings) do
-                askForHeji(self, wujing, victim)
+                if wujing:objectName() ~= victim:objectName() then
+                    askForHeji(self, wujing, victim)
+                end
             end
         end
         return false


### PR DESCRIPTION
## 拉取请求简述
调整【合击】目标不能为自己

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
