### PR TITLE
fix: 修正神太史慈【神著】多次选择二选项后新回合不能出杀问题

### DIFF
--- a/extensions/LayingPlansSincerityPackage.lua
+++ b/extensions/LayingPlansSincerityPackage.lua
@@ -774,7 +774,7 @@ LuaShenzhu = sgs.CreateTriggerSkill {
                 player:drawCards(3, self:objectName())
                 if player:getMark('LuaShenzhuForbid') == 0 then
                     room:addPlayerMark(player, 'LuaShenzhuForbid')
-                    room:setPlayerCardLimitation(player, 'use', 'Slash|.|.|.', true)                    
+                    room:setPlayerCardLimitation(player, 'use', 'Slash|.|.|.', true)
                 end
             end
         end

--- a/extensions/LayingPlansSincerityPackage.lua
+++ b/extensions/LayingPlansSincerityPackage.lua
@@ -701,6 +701,7 @@ LuaPowei = sgs.CreateTriggerSkill {
             ['from'] = player,
             ['arg'] = self:objectName(),
         })
+        room:notifySkillInvoked(player, self:objectName())
         room:broadcastSkillInvoke('LuaPowei', 2)
         if room:changeMaxHpForAwakenSkill(player, 0) then
             room:acquireSkill(player, 'LuaShenzhu')
@@ -737,6 +738,7 @@ LuaPoweiFailed = sgs.CreateTriggerSkill {
             ['from'] = player,
             ['arg'] = 'LuaPowei',
         })
+        room:notifySkillInvoked(player, 'LuaPowei')
         room:broadcastSkillInvoke('LuaPowei', 3)
         rinsan.recover(dying.who, 1 - dying.who:getHp(), player)
         for _, p in sgs.qlist(room:getAlivePlayers()) do
@@ -770,8 +772,10 @@ LuaShenzhu = sgs.CreateTriggerSkill {
             elseif choice == choices[2] then
                 -- 摸三牌，然后本回合内不能用杀
                 player:drawCards(3, self:objectName())
-                room:addPlayerMark(player, 'LuaShenzhuForbid')
-                room:setPlayerCardLimitation(player, 'use', 'Slash|.|.|.', true)
+                if player:getMark('LuaShenzhuForbid') == 0 then
+                    room:addPlayerMark(player, 'LuaShenzhuForbid')
+                    room:setPlayerCardLimitation(player, 'use', 'Slash|.|.|.', true)                    
+                end
             end
         end
     end,


### PR DESCRIPTION
## 拉取请求简述
1. 修正神太史慈多次摸三张牌不能在新的自己回合出杀问题
2. 添加神太史慈破围头像技能文字效果

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
