### PR TITLE
fix: 修正死亡后移出游戏

### DIFF
--- a/extensions/PuyuanEquipCardPackage.lua
+++ b/extensions/PuyuanEquipCardPackage.lua
@@ -364,7 +364,19 @@ LuaMoveOutPuyuanEquips = sgs.CreateTriggerSkill {
                 if ids:isEmpty() then
                     return false
                 end
-                if move.from and move.from:objectName() ~= player:objectName() then
+                if move.from and move.from:isAlive() and move.from:objectName() ~= player:objectName() then
+                    return false
+                end
+                local mover = player
+                if move.from and (not move.from:isAlive()) then
+                    for _, p in sgs.qlist(room:getAllPlayers(true)) do
+                        if p:objectName() == move.from:objectName() then
+                            mover = p
+                            break
+                        end
+                    end
+                end
+                if not mover then
                     return false
                 end
                 for _, id in sgs.qlist(ids) do
@@ -374,22 +386,22 @@ LuaMoveOutPuyuanEquips = sgs.CreateTriggerSkill {
                         data:setValue(move)
                     end
                 end
-                local reason = sgs.CardMoveReason(sgs.CardMoveReason_S_REASON_PUT, player:objectName(), 'moveout', '')
+                local reason = sgs.CardMoveReason(sgs.CardMoveReason_S_REASON_PUT, mover:objectName(), 'moveout', '')
                 local moves = sgs.CardsMoveList()
                 if not hand_ids:isEmpty() then
-                    local hand_move = sgs.CardsMoveStruct(hand_ids, player, nil, sgs.Player_PlaceHand, sgs.Player_DrawPile,
+                    local hand_move = sgs.CardsMoveStruct(hand_ids, mover, nil, sgs.Player_PlaceHand, sgs.Player_DrawPile,
                         reason)
                     moves:append(hand_move)
                 end
                 if not equip_ids:isEmpty() then
-                    local equip_move = sgs.CardsMoveStruct(equip_ids, player, nil, sgs.Player_PlaceEquip,
+                    local equip_move = sgs.CardsMoveStruct(equip_ids, mover, nil, sgs.Player_PlaceEquip,
                         sgs.Player_DrawPile, reason)
                     moves:append(equip_move)
                 end
                 room:notifyMoveCards(true, moves, false)
                 for _, id in sgs.qlist(ids) do
                     local card = sgs.Sanguosha:getCard(id)
-                    player:removeCard(card, places[id])
+                    mover:removeCard(card, places[id])
                     room:setCardMapping(id, nil, sgs.Player_PlaceUnknown)
                 end
                 room:notifyMoveCards(false, moves, false)


### PR DESCRIPTION
## 拉取请求简述
修正蒲元武器在死亡后进入弃牌堆时不正确问题

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #730 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
