### PR TITLE
fix: 修正谋孙策【激昂】多目标摸牌问题

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -7239,7 +7239,7 @@ LuaAosi = sgs.CreateTriggerSkill {
         if not damage.to:isAlive() then
             return false
         end
-        if player:inMyAttackRange(damage.to) then
+        if player:objectName() ~= damage.to:objectName() and player:inMyAttackRange(damage.to) then
             -- 如果没有被雄乱影响
             if damage.to:getMark('@be_fucked-Clear') == 0 then
                 room:broadcastSkillInvoke(self:objectName())
@@ -7275,11 +7275,11 @@ LuaAosiClear = sgs.CreateTriggerSkill {
     on_trigger = function(self, event, player, data, room)
         if data:toPhaseChange().from == sgs.Player_Play then
             rinsan.clearAllMarksContains(player, 'LuaAosi')
-            room:setPlayerMark(player, 'fuck_caocao-Clear', 0)
+            room:removePlayerMark(player, 'fuck_caocao-Clear')
             for _, p in sgs.qlist(room:getOtherPlayers(player)) do
                 if p:getMark('LuaAosi_biu') > 0 then
                     room:setPlayerMark(p, 'LuaAosi_biu', 0)
-                    room:setPlayerMark(p, '@be_fucked-Clear', 0)
+                    room:removePlayerMark(p, '@be_fucked-Clear')
                 end
             end
         end

--- a/extensions/StrategicAttackTogetherPackage.lua
+++ b/extensions/StrategicAttackTogetherPackage.lua
@@ -167,7 +167,18 @@ LuaMouJiang = sgs.CreateTriggerSkill {
             end
             return false
         end
-        if event == sgs.TargetSpecified or (event == sgs.TargetConfirmed and use.to:contains(player)) then
+        if event == sgs.TargetSpecified then
+            if use.card:isKindOf('Duel') or (use.card:isKindOf('Slash') and use.card:isRed()) then
+                for _, p in sgs.qlist(use.to) do
+                    if player:askForSkillInvoke(self:objectName(), data) then
+                        player:drawCards(1, self:objectName())
+                        room:broadcastSkillInvoke(self:objectName())
+                    else
+                        break
+                    end
+                end
+            end
+        elseif(event == sgs.TargetConfirmed and use.to:contains(player)) then
             if use.card:isKindOf('Duel') or (use.card:isKindOf('Slash') and use.card:isRed()) then
                 if player:askForSkillInvoke(self:objectName(), data) then
                     player:drawCards(1, self:objectName())

--- a/extensions/StrategicAttackTogetherPackage.lua
+++ b/extensions/StrategicAttackTogetherPackage.lua
@@ -169,7 +169,7 @@ LuaMouJiang = sgs.CreateTriggerSkill {
         end
         if event == sgs.TargetSpecified then
             if use.card:isKindOf('Duel') or (use.card:isKindOf('Slash') and use.card:isRed()) then
-                for _, p in sgs.qlist(use.to) do
+                for _, _ in sgs.qlist(use.to) do
                     if player:askForSkillInvoke(self:objectName(), data) then
                         player:drawCards(1, self:objectName())
                         room:broadcastSkillInvoke(self:objectName())


### PR DESCRIPTION
## 拉取请求简述
1. 修正谋孙策激昂摸牌数量问题
2. 修正星魏延骜肆标记清理问题

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #796 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
