### PR TITLE
fix: 修正取消目标技能重复判定问题

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -7653,7 +7653,7 @@ LuaJueyongUse = sgs.CreateTriggerSkill {
                 newCard:setSkillName(items[2])
                 cd:takeOver(newCard)
             end
-            
+
             room:setCardFlag(cd, 'LuaJueyongUse')
             local tag = string.format('%s_%d', JUE_PILE_NAME, id)
             if cd:isKindOf('Collateral') then

--- a/extensions/GroupFriendPackage.lua
+++ b/extensions/GroupFriendPackage.lua
@@ -1666,7 +1666,7 @@ LuaJiaren = sgs.CreateTriggerSkill {
     events = {sgs.TargetConfirming},
     on_trigger = function(self, event, player, data, room)
         local use = data:toCardUse()
-        if use.card and use.card:isKindOf('Slash') then
+        if use.card and use.card:isKindOf('Slash') and use.to:contains(player) then
             if use.from and use.from:objectName() ~= player:objectName() then
                 room:sendCompulsoryTriggerLog(player, self:objectName())
                 room:broadcastSkillInvoke(self:objectName())

--- a/extensions/LayingPlansSincerityPackage.lua
+++ b/extensions/LayingPlansSincerityPackage.lua
@@ -573,7 +573,7 @@ LuaDulie = sgs.CreateTriggerSkill {
     frequency = sgs.Skill_Compulsory,
     on_trigger = function(self, event, player, data, room)
         local use = data:toCardUse()
-        if use.card and use.card:isKindOf('Slash') then
+        if use.card and use.card:isKindOf('Slash') and use.to:contains(player) then
             if use.from and use.from:getHp() > player:getHp() then
                 room:sendCompulsoryTriggerLog(player, self:objectName())
                 room:broadcastSkillInvoke(self:objectName())


### PR DESCRIPTION
## 拉取请求简述
修正取消目标技能重复判定问题，包含如下技能
- 阿杰【嘉人】
- 神太史慈【笃烈】

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #837 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
