### PR TITLE
fix: 调整神太史慈【破围】移动标记时机

### DIFF
--- a/extensions/LayingPlansSincerityPackage.lua
+++ b/extensions/LayingPlansSincerityPackage.lua
@@ -729,13 +729,28 @@ LuaPoweiHelper = sgs.CreateTriggerSkill {
                 player:loseMark('@LuaPowei', player:getMark('@LuaPowei'))
             end
         elseif event == sgs.EventPhaseStart then
-            if player:getMark('@LuaPowei') == 0 or player:getPhase() ~= sgs.Player_RoundStart then
+            -- 先判断是否是回合开始时
+            if player:getPhase() ~= sgs.Player_RoundStart then
                 return false
             end
+            -- 若为神太史慈，则移动标记
+            if player:hasSkill('LuaPowei') and player:getMark('LuaPowei') == 0 then
+                room:broadcastSkillInvoke('LuaPowei', 1)
+                moveLuaPoweiMark(player)
+            end
+            -- 若为非神太史慈，则执行下一步：判断是否有围标记
+            if player:getMark('@LuaPowei') == 0 then
+                return false
+            end
+            -- 有围标记，则询问神太史慈
             local stscs = room:findPlayersBySkillName('LuaPowei')
             local _data = sgs.QVariant()
             _data:setValue(player)
             for _, stsc in sgs.qlist(stscs) do
+                -- 若中途挨打了，就中止询问
+                if player:getMark('@LuaPowei') == 0 then
+                    break
+                end
                 room:broadcastSkillInvoke('LuaPowei', 1)
                 room:askForUseCard(stsc, '@@LuaPoweiHelper', 'LuaPowei_ask', -1, sgs.Card_MethodNone)
             end
@@ -744,9 +759,6 @@ LuaPoweiHelper = sgs.CreateTriggerSkill {
                 local stscs = room:findPlayersBySkillName('LuaPowei')
                 for _, stsc in sgs.qlist(stscs) do
                     rinsan.removeFromAttackRange(player, stsc)
-                end
-                if player:hasSkill('LuaPowei') and player:getMark('LuaPowei') == 0 then
-                    moveLuaPoweiMark(player)
                 end
             end
         end


### PR DESCRIPTION
## 拉取请求简述
调整神太史慈【破围】移动标记时机到回合开始时

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #888 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
