### PR TITLE
fix: 修正神张飞“巡使”响应使用无色牌场景不记录的问题

### DIFF
--- a/extensions/DevineForcePackage.lua
+++ b/extensions/DevineForcePackage.lua
@@ -433,17 +433,22 @@ LuaXunshiTargetMod = sgs.CreateTargetModSkill {
 
 LuaXunshiUsed = sgs.CreateTriggerSkill {
     name = 'LuaXunshiUsed',
-    events = {sgs.CardUsed},
+    events = {sgs.CardUsed, sgs.CardResponded},
     global = true,
     on_trigger = function(self, event, player, data, room)
-        local use = data:toCardUse()
-        if use.card:isKindOf('SkillCard') then
+        local card
+        if event == sgs.CardUsed then
+            card = data:toCardUse().card
+        else
+            card = data:toCardResponse().m_card
+        end
+        if (not card) or card:isKindOf('SkillCard') then
             return false
         end
         if player:getMark('LuaXunshiAdd') >= 4 then
             return false
         end
-        if use.card:getSuit() == sgs.Card_NoSuit then
+        if card:getSuit() == sgs.Card_NoSuit then
             room:addPlayerMark(player, 'LuaXunshiAdd')
         end
     end,


### PR DESCRIPTION
## 拉取请求简述
修正神张飞“巡使”响应使用无色牌场景不记录的问题，如八卦阵使用的无色闪

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #920 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
