### PR TITLE
fix: 修正毅谋 AI 与 Table 打乱起始下标错误问题

### DIFF
--- a/lua/QSanguoshaLuaFunction.lua
+++ b/lua/QSanguoshaLuaFunction.lua
@@ -821,8 +821,8 @@ end
 -- 打乱 table
 function shuffleTable(table)
     local len = #table
-    for i = 0, len - 1, 1 do
-        local j = random(i, len - 1)
+    for i = 1, len, 1 do
+        local j = random(i, len)
         table[i], table[j] = table[j], table[i]
     end
 end

--- a/lua/ai/ExpansionPackage-ai.lua
+++ b/lua/ai/ExpansionPackage-ai.lua
@@ -2185,7 +2185,6 @@ sgs.ai_skill_askforyiji['LuaYimou'] = function(self, card_ids)
     -- 没有友方，选择最差的牌给随机一人
     local all_players = self.room:getOtherPlayers(self.player)
     local all_players_table = sgs.QList2Table(all_players)
-    rinsan.shuffleTable(all_players_table)
 
     self:sortByKeepValue(cards)
     id = cards[1]:getId()


### PR DESCRIPTION
## 拉取请求简述
修正毅谋 AI 与 Table 打乱起始下标错误问题
1. 毅谋 AI 代码使用了两次随机，删去第一次的打乱顺序
2. Table shuffle 公共方法中使用 0 作为起始下标，修改为 1

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #926 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
