### PR TITLE
fix: 协力增加即时成功判断逻辑

### DIFF
--- a/extensions/StrategicAttackTogetherPackage.lua
+++ b/extensions/StrategicAttackTogetherPackage.lua
@@ -420,8 +420,6 @@ LuaXieji = sgs.CreateTriggerSkill {
         local to = room:askForPlayerChosen(player, available_targets, self:objectName(), 'LuaXieji-choose', true, true)
         if to then
             room:broadcastSkillInvoke(self:objectName(), 1)
-            uniteEfforts.setUpBackupTag(player)
-            room:addPlayerMark(player, uniteEfforts.INVOKING_MARK)
             uniteEfforts.askForUniteEfforts(player, to, self:objectName(), true)
         end
     end,

--- a/extensions/UniteEffortsPackage.lua
+++ b/extensions/UniteEffortsPackage.lua
@@ -245,15 +245,31 @@ local function getUniteEffortsMarks(player)
     return marks
 end
 
+-- 基础失败（提示失败消息）
+local function UNITE_BASIC_FAILED_FUNC(invoker, collaborator, skillName)
+    local room = invoker:getRoom()
+    rinsan.sendLogMessage(room, '#UniteEfforts-Failure', {
+        ['from'] = invoker,
+        ['to'] = collaborator,
+        ['arg'] = skillName .. 'UniteEfforts',
+    })
+end
+
+-- 基础成功（提示成功消息）
+local function UNITE_BASIC_BONUS_FUNC(invoker, collaborator, skillName)
+    local room = invoker:getRoom()
+    rinsan.sendLogMessage(room, '#UniteEfforts-Success', {
+        ['from'] = invoker,
+        ['to'] = collaborator,
+        ['arg'] = skillName .. 'UniteEfforts',
+    })
+end
+
 -- 协力成功的不同对应
 local UNITE_EFFORTS_BONUS_FUNCS = {
     ['LuaXieji'] = function(invoker, collaborator)
+        UNITE_BASIC_BONUS_FUNC(invoker, collaborator, 'LuaXieji')
         local room = invoker:getRoom()
-        rinsan.sendLogMessage(room, '#UniteEfforts-Success', {
-            ['from'] = invoker,
-            ['to'] = collaborator,
-            ['arg'] = 'LuaXiejiUniteEfforts',
-        })
         room:askForUseCard(invoker, '@@LuaXieji', '@LuaXieji')
     end,
 }
@@ -263,14 +279,7 @@ local UNITE_EFFORTS_INSTANT_BONUS_FUNCS = {}
 
 -- 协力失败不同对应
 local UNITE_EFFORTS_FAILED_FUNCS = {
-    ['LuaXieji'] = function(invoker, collaborator)
-        local room = invoker:getRoom()
-        rinsan.sendLogMessage(room, '#UniteEfforts-Failure', {
-            ['from'] = invoker,
-            ['to'] = collaborator,
-            ['arg'] = 'LuaXiejiUniteEfforts',
-        })
-    end,
+    ['LuaXieji'] = UNITE_BASIC_FAILED_FUNC,
 }
 
 local function doUniteEfforts(player)
@@ -297,12 +306,14 @@ local function doUniteEfforts(player)
         if success then
             local bonusFunc = UNITE_EFFORTS_BONUS_FUNCS[skillName]
             if bonusFunc then
+                -- 成功通常更多自定义的情况，不传 skillName 亦可
                 bonusFunc(from, player)
             end
         else
             local failFunc = UNITE_EFFORTS_FAILED_FUNCS[skillName]
             if failFunc then
-                failFunc(from, player)
+                -- 多传 skillName 参数用于适配基础失败方法
+                failFunc(from, player, skillName)
             end
         end
         ::next_mark::

--- a/extensions/UniteEffortsPackage.lua
+++ b/extensions/UniteEffortsPackage.lua
@@ -84,6 +84,7 @@ function canBeAskedForUniteEfforts(player, ignoreChosen)
 end
 
 -- 获取备份 Tag 名称
+-- 由于协力通常会有回合外的记录，所以此处记录时需要分开，将本回合的记录保留
 local function getBackupTagName(name)
     return name .. '_Backup'
 end
@@ -109,7 +110,7 @@ end
 
 -- 询问协力，暴露的外部接口
 function askForUniteEfforts(from, to, skillName, isFromChoose, ignoreChosen)
-    -- 在此之前需要启动备份当前回合记录
+    -- 在此之前需要启动备份
     prepareUniteEfforts(from)
     local room = from:getRoom()
     local chooser = isFromChoose and from or to


### PR DESCRIPTION
## 拉取请求简述
1. 调整协力对外暴露接口
2. 协力增加即时成功判断逻辑

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #918 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
