### PR TITLE
fix: 修正界沮授渐营花色判断条件

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -8285,9 +8285,9 @@ LuaJianying = sgs.CreateTriggerSkill {
         end
         local suit = player:getMark(LuaJianyingSuitMark)
         local number = player:getMark(LuaJianyingNumberMark)
-        local card_suit = rinsan.Suit2Num(card:getSuit())
+        local card_suit = rinsan.Suit2Num(card:getSuit(), true)
         local card_number = card:getNumber()
-        player:setMark(LuaJianyingSuitMark, rinsan.Suit2Num(card:getSuit()))
+        player:setMark(LuaJianyingSuitMark, rinsan.Suit2Num(card:getSuit(), true))
         player:setMark(LuaJianyingNumberMark, card_number)
         if number == card_number or suit == card_suit then
             if room:askForSkillInvoke(player, self:objectName(), data) then

--- a/lua/QSanguoshaLuaFunction.lua
+++ b/lua/QSanguoshaLuaFunction.lua
@@ -1443,12 +1443,14 @@ local suits = {
 }
 
 -- 花色转数字
-function Suit2Num(suit)
+function Suit2Num(suit, no_suit_as_positive)
+    -- 是否将无花色的视为非零数字，此处用于修正渐营 BUG
+    no_suit_as_positive = no_suit_as_positive or false
     local f = suitNumFuncs[suit]
     if f then
         return f()
     end
-    return 0
+    return no_suit_as_positive and 5 or 0
 end
 
 function Num2Suit(num)


### PR DESCRIPTION
## 拉取请求简述
调整花色转换数字函数，以修正渐营对使用无花色摸牌触发条件

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #963 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
