### PR TITLE
fix: 修正势太史慈“酣战”和“战烈”部分情况下不显示技能名提示问题

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -8535,6 +8535,7 @@ LuaHanzhanCard = sgs.CreateSkillCard {
         local source = effect.from
         local target = effect.to
         local room = source:getRoom()
+        room:notifySkillInvoked(source, self:objectName())
         local sourceDraw = getHanzhanNum(source, source) - source:getHandcardNum()
         local targetDraw = getHanzhanNum(source, target) - target:getHandcardNum()
         if sourceDraw > 0 then
@@ -8669,6 +8670,7 @@ LuaZhanlie = sgs.CreateTriggerSkill {
             room:setCardFlag(zhanlieSlash, choice)
         end
         if target then
+            room:notifySkillInvoked(player, self:objectName())
             room:broadcastSkillInvoke(self:objectName(), rinsan.random(2, 3))
             room:useCard(sgs.CardUseStruct(zhanlieSlash, player, target))
             player:loseAllMarks(LuaZhanlieMark)


### PR DESCRIPTION
## 拉取请求简述
修正势太史慈“酣战”和“战烈”部分情况下不显示技能名提示问题

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #966 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
