### PR TITLE
fix: 修正势太史慈和审配 AI

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -8672,8 +8672,8 @@ LuaZhanlie = sgs.CreateTriggerSkill {
         if target then
             room:notifySkillInvoked(player, self:objectName())
             room:broadcastSkillInvoke(self:objectName(), rinsan.random(2, 3))
-            room:useCard(sgs.CardUseStruct(zhanlieSlash, player, target))
             player:loseAllMarks(LuaZhanlieMark)
+            room:useCard(sgs.CardUseStruct(zhanlieSlash, player, target))
         end
         return false
     end,

--- a/lua/ai/ExpansionPackage-ai.lua
+++ b/lua/ai/ExpansionPackage-ai.lua
@@ -1283,6 +1283,10 @@ end
 sgs.ai_skill_invoke.LuaShouye = function(self, data)
     local use = data:toCardUse()
     local card = use.card
+    -- 队友使用的先不发动
+    if self:isFriend(use.from) then
+        return false
+    end
     -- 判断牌是否为好牌，不是就发动
     if card:isKindOf('Peach') or card:isKindOf('AmazingGrace') or card:isKindOf('GodSalvation') or card:isKindOf('ExNihilo') then
         return false
@@ -2211,4 +2215,26 @@ sgs.ai_skill_choice['LuaQianxin'] = function(self, choices, data)
     end
     -- 随机
     return items[rinsan.random(1, 2)]
+end
+
+-- 战烈弃牌
+sgs.ai_skill_discard['LuaZhanlieDiscard'] = function(self, discard_num, min_num, optional, method)
+    local cards = self.player:getCards('he')
+    cards = sgs.QList2Table(cards)
+    self:sortByKeepValue(cards, true)
+    local to_discard = {}
+    local jink_num = self:getCardsNum('Jink')
+    local chosen_card
+    for i = 1, discard_num do
+        chosen_card = cards[i]
+        table.insert(to_discard, cards[i]:getEffectiveId())
+    end
+    -- 没有闪的情况下，不弃牌
+    if jink_num == 0 then
+        return {}
+    elseif jink_num == 1 then
+        -- 只有一张闪，若当前最差的牌为闪，则不弃牌
+        return (not chosen_card:isKindOf('Jink')) and to_discard or {}
+    end
+    return to_discard
 end

--- a/lua/ai/ExpansionPackage-ai.lua
+++ b/lua/ai/ExpansionPackage-ai.lua
@@ -2221,7 +2221,7 @@ end
 sgs.ai_skill_discard['LuaZhanlieDiscard'] = function(self, discard_num, min_num, optional, method)
     local cards = self.player:getCards('he')
     cards = sgs.QList2Table(cards)
-    self:sortByKeepValue(cards, true)
+    self:sortByKeepValue(cards)
     local to_discard = {}
     local jink_num = self:getCardsNum('Jink')
     local chosen_card


### PR DESCRIPTION
## 拉取请求简述
1. 修正势太史慈 AI 默认选择战烈不弃牌问题
2. 修正审配守邺发动 AI，默认队友用牌不发动
3. 调整战烈失去标记时机

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #971 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
