### PR TITLE
fix: 势太史慈技能选择后提示增补

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -8666,6 +8666,10 @@ LuaZhanlie = sgs.CreateTriggerSkill {
             if choice == 'cancel' then
                 break
             end
+            rinsan.sendLogMessage(room, '#choose', {
+                ['from'] = target,
+                ['arg'] = choice,
+            })
             table.removeAll(choices, choice)
             room:setCardFlag(zhanlieSlash, choice)
         end
@@ -8767,9 +8771,15 @@ LuaZhenfengCard = sgs.CreateSkillCard {
             table.insert(choices, 'LuaZhenfengChangeValue')
         end
         local mainChoice = room:askForChoice(source, 'LuaZhenfeng', table.concat(choices, '+'))
+        rinsan.sendLogMessage(room, '#LuaZhenfengChoose', {
+            ['from'] = source,
+            ['arg'] = 'LuaZhenfeng',
+            ['arg2'] = mainChoice,
+        })
         if mainChoice == 'LuaZhenfengRecover' then
             -- 回复 2 点体力
             rinsan.recover(source, 2, source)
+            room:notifySkillInvoked(source, 'LuaZhenfeng')
             room:broadcastSkillInvoke('LuaZhenfeng', 4)
             return
         end
@@ -8779,14 +8789,30 @@ LuaZhenfengCard = sgs.CreateSkillCard {
             local choice = room:askForChoice(source, 'LuaZhenfeng-Hanzhan', table.concat(changeValueChoices, '+'))
             -- 即使取消也是 4，不做额外判断
             local index = rinsan.getPos(changeValueChoices, choice)
+            if choice ~= 'cancel' then
+                rinsan.sendLogMessage(room, '#LuaZhenfengChoose', {
+                    ['from'] = source,
+                    ['arg'] = 'LuaHanzhan',
+                    ['arg2'] = choice,
+                })
+            end
             room:setPlayerMark(source, 'LuaZhenfeng-Hanzhan', index)
+            room:notifySkillInvoked(source, 'LuaZhenfeng')
             room:broadcastSkillInvoke('LuaZhenfeng', index)
         end
         if source:hasSkill('LuaZhanlie') then
             local choice = room:askForChoice(source, 'LuaZhenfeng-Zhanlie', table.concat(changeValueChoices, '+'))
             -- 即使取消也是 4，不做额外判断
             local index = rinsan.getPos(changeValueChoices, choice)
+            if choice ~= 'cancel' then
+                rinsan.sendLogMessage(room, '#LuaZhenfengChoose', {
+                    ['from'] = source,
+                    ['arg'] = 'LuaZhanlie',
+                    ['arg2'] = choice,
+                })
+            end
             room:setPlayerMark(source, 'LuaZhenfeng-Zhanlie', index)
+            room:notifySkillInvoked(source, 'LuaZhenfeng')
             room:broadcastSkillInvoke('LuaZhenfeng', index)
         end
     end,

--- a/lang/zh_CN/Package/ExpansionPackage.lua
+++ b/lang/zh_CN/Package/ExpansionPackage.lua
@@ -738,4 +738,5 @@ return {
     ['LuaZhenfeng-CurrentAlivePlayers'] = '存活角色数',
     ['LuaZhenfeng-Zhanlie'] = '振锋-修改战烈',
     ['LuaZhenfeng-Hanzhan'] = '振锋-修改酣战',
+    ['#LuaZhenfengChoose'] = '%from 为 %arg 选择了 %arg2',
 }


### PR DESCRIPTION
## 拉取请求简述
势太史慈技能选择后提示增补，将战烈、振锋的选项显示出来

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #973 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
