### PR TITLE
fix: 叫分后移除小于等于的叫分选项

### DIFF
--- a/lua/ai/LandlordsPackage-ai.lua
+++ b/lua/ai/LandlordsPackage-ai.lua
@@ -1,5 +1,7 @@
 -- 斗地主包 AI
 -- Created by DZDcyj at 2021/10/9
+-- 引入封装函数包
+local rinsan = require('QSanguoshaLuaFunction')
 
 -- 是否发动飞扬
 sgs.ai_skill_use['@@LuaFeiyang'] = function(self, prompt, method)
@@ -30,4 +32,23 @@ sgs.ai_skill_choice['LuaNongmin'] = function(self, choices)
     end
     -- 选倒数第二个摸牌
     return items[#items - 1]
+end
+
+-- 叫分
+sgs.ai_skill_choice['rob-landlord'] = function(self, choices)
+    local items = choices:split('+')
+    local random_num = rinsan.random(1, 100)
+    if table.contains(items, '1x') and random_num <= 40 then
+        -- AI 20% 概率叫 1 分
+        return '1x'
+    end
+    if table.contains(items, '2x') and random_num <= 20 then
+        -- AI 20% 概率叫 2 分
+        return '2x'
+    end
+    if table.contains(items, '3x') and random_num <= 10 then
+        -- AI 10% 概率叫 3 分
+        return '3x'
+    end
+    return '0x'
 end


### PR DESCRIPTION
## 拉取请求简述
叫分后移除小于等于的叫分选项，例如叫了 2 分之后，移除 1 分和 2 分选项

### 自验截图
![QQ_1747995016270](https://github.com/user-attachments/assets/3bc8d3a7-1844-4d19-a058-ceed1521c912)


### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #979 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
