### PR TITLE
fix: 势太史慈“战烈”技能适配【朱雀羽扇】

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -8645,7 +8645,14 @@ LuaZhanlie = sgs.CreateTriggerSkill {
         if curr <= 0 then
             return false
         end
-        local zhanlieSlash = sgs.Sanguosha:cloneCard('slash', sgs.Card_NoSuit, 0)
+        local zhanlieType = 'slash'
+        if player:hasWeapon('fan') then
+            zhanlieType = room:askForChoice(player, self:objectName(), 'slash+fire_slash+cancel')
+        end
+        if zhanlieType == 'cancel' then
+            return false
+        end
+        local zhanlieSlash = sgs.Sanguosha:cloneCard(zhanlieType, sgs.Card_NoSuit, 0)
         zhanlieSlash:setSkillName('_LuaZhanlieSlash')
         local splayers = sgs.SPlayerList()
         for _, p in sgs.qlist(room:getAlivePlayers()) do
@@ -8677,7 +8684,9 @@ LuaZhanlie = sgs.CreateTriggerSkill {
             room:notifySkillInvoked(player, self:objectName())
             room:broadcastSkillInvoke(self:objectName(), rinsan.random(2, 3))
             player:loseAllMarks(LuaZhanlieMark)
-            room:useCard(sgs.CardUseStruct(zhanlieSlash, player, target))
+            local card_use = sgs.CardUseStruct(zhanlieSlash, player, target)
+            card_use.m_isOwnerUse = false
+            room:useCard(card_use)
         end
         return false
     end,


### PR DESCRIPTION
## 拉取请求简述
势太史慈“战烈”技能适配【朱雀羽扇】
1. 在装备朱雀羽扇后，发动“战烈”选择目标之前，若装备【朱雀羽扇】则会先提示选择【杀】的类型
2. 在装备朱雀羽扇后，即使选择普通【杀】也不会再次询问是否发动朱雀羽扇

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #983 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
