### PR TITLE
fix: 饿人类“寻衅”技能适配【朱雀羽扇】

### DIFF
--- a/extensions/ExpansionPackage.lua
+++ b/extensions/ExpansionPackage.lua
@@ -8080,8 +8080,9 @@ LuaChengzhaoMark = sgs.CreateTriggerSkill {
         local move = data:toMoveOneTime()
         if not room:getTag('FirstRound'):toBool() and move.to and move.to:objectName() == player:objectName() then
             for _, id in sgs.qlist(move.card_ids) do
-                if room:getCardOwner(id):objectName() == player:objectName() and room:getCardPlace(id) ==
-                    sgs.Player_PlaceHand then
+                local owner = room:getCardOwner(id)
+                local place = room:getCardPlace(id)
+                if owner and owner:objectName() == player:objectName() and place and place == sgs.Player_PlaceHand then
                     room:addPlayerMark(player, self:objectName() .. 'engine')
                     if player:getMark(self:objectName() .. 'engine') > 0 then
                         room:addPlayerMark(player, 'LuaChengzhao-Clear')

--- a/extensions/GroupFriendPackage.lua
+++ b/extensions/GroupFriendPackage.lua
@@ -1113,10 +1113,21 @@ LuaXunxin = sgs.CreateTriggerSkill {
                 winner = pindian.to
                 loser = pindian.from
             end
-            local slash = sgs.Sanguosha:cloneCard('slash', sgs.Card_NoSuit, 0)
+            local type = 'slash'
+            local dummy_slash = sgs.Sanguosha:cloneCard(type, sgs.Card_NoSuit, 0)
+            local dummy_use = sgs.CardUseStruct(dummy_slash, winner, loser)
+            local _dummy_use_data = sgs.QVariant()
+            _dummy_use_data:setValue(dummy_use)
+            if winner:hasWeapon('fan') and room:askForSkillInvoke(winner, 'fan', _dummy_use_data) then
+                type = 'fire_slash'
+            end
+            local slash = sgs.Sanguosha:cloneCard(type, sgs.Card_NoSuit, 0)
             slash:setSkillName('_LuaXunxin')
             if winner:canSlash(loser, slash, false) then
-                room:useCard(sgs.CardUseStruct(slash, winner, loser))
+                if type == 'fire_slash' then
+                    room:setEmotion(winner, 'weapon/fan')
+                end
+                room:useCard(sgs.CardUseStruct(slash, winner, loser, false))
             end
             room:addPlayerMark(winner, 'LuaXunxinWon-Clear')
             return false


### PR DESCRIPTION
## 拉取请求简述
饿人类“寻衅”技能适配【朱雀羽扇】
1. 在装备朱雀羽扇后，因“寻衅”出【杀】前，若装备【朱雀羽扇】则会先提示是否发动，若发动则改为火【杀】，不发动也不会再次询问
2. 为装备【朱雀羽扇】场景下出火【杀】添加动画

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #987 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
