### PR TITLE
fix: 修正武诸葛亮“情势”令其他角色摸牌选项播放多次语音问题

### DIFF
--- a/extensions/MartialTemplePackage.lua
+++ b/extensions/MartialTemplePackage.lua
@@ -407,7 +407,9 @@ LuaQingshi = sgs.CreateTriggerSkill {
         elseif choice == 'LuaQingshi-OtherDraw' then
             room:askForUseCard(player, '@@LuaQingshi', '@LuaQingshi-OtherDraw')
         end
-        room:broadcastSkillInvoke(self:objectName())
+        if choice ~= 'LuaQingshi-OtherDraw' then
+            room:broadcastSkillInvoke(self:objectName())
+        end
         room:addPlayerMark(player, mark)
         return false
     end,


### PR DESCRIPTION
## 拉取请求简述
修正武诸葛亮“情势”令其他角色摸牌选项播放多次语音问题

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #993 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
