### PR TITLE
refactor: 提取共砺公共接口方法

### DIFF
--- a/extensions/GongliCommonMethod.lua
+++ b/extensions/GongliCommonMethod.lua
@@ -1,0 +1,39 @@
+-- 日神杀 共砺 技能通用封装模块
+-- Created by DZDcyj at 2025/6/7
+module('GongliCommonMethod', package.seeall)
+
+-- 引入封装函数包
+local rinsan = require('QSanguoshaLuaFunction')
+
+-- 忽略本文件中未引用 global variable 的警告
+-- luacheck: push ignore 131
+
+-- 判断本人是否是对应友武将
+local function isYouGeneral(source, youGeneralName)
+    return source:getGeneralName() == generalName or source:getGeneral2Name() == generalName
+end
+
+-- 总对外接口，是否可以发动共砺
+-- source: 发动技能的武将
+-- gongli_skill: 共砺技能名称
+-- gongli_friend: 共砺友武将名称
+-- 返回值：如果可以发动共砺，则返回 true，否则返回 false
+function gongliSkillInvokable(source, gongli_skill, gongli_friend)
+    -- 如果自身没有共砺技能，那必然不能发动
+    if not source:hasSkill(gongli_skill) then
+        return false
+    end
+    -- 如果本人即是友武将，即可发动
+    if isYouGeneral(source, gongli_friend) then
+        return true
+    end
+    -- 判断其他的同阵营友武将
+    for _, you_general in sgs.qlist(rinsan.getOtherPlayersWithGivenGeneralName(source, gongli_friend)) do
+        if rinsan.isSameCamp(source, you_general) then
+            return true
+        end
+    end
+    return false
+end
+
+-- luacheck: pop

--- a/extensions/OldFriendCardPackage.lua
+++ b/extensions/OldFriendCardPackage.lua
@@ -3,13 +3,18 @@
 module('extensions.OldFriendCardPackage', package.seeall)
 extension = sgs.Package('OldFriendCardPackage', sgs.Package_CardPack)
 
+-- 引入封装函数包
 local rinsan = require('QSanguoshaLuaFunction')
+local gongli = require('GongliCommonMethod')
 
 local skillList = sgs.SkillList()
 
 -- 友诸葛亮、友庞统名称
 local YouZhugeliang_Name = 'YouZhugeliang'
 local YouPangtong_Name = 'YouPangtong'
+
+-- 友徐庶技能名称
+local YouXushu_Gongli_SkillName = 'YouXushu_Gongli'
 
 -- 玄剑
 xuanjian_sword = sgs.CreateWeapon {
@@ -22,32 +27,9 @@ xuanjian_sword = sgs.CreateWeapon {
 
 xuanjian_sword:setParent(extension)
 
--- 判断本人是否是对应武将
-local function isGeneral(source, generalName)
-    return source:getGeneralName() == generalName or source:getGeneral2Name() == generalName
-end
-
--- 共砺接口
--- 判断是否有其他同阵营友武将
--- source: 友武将，技能发动方
--- you_general_name_to_check: 需要检查的友武将名称
--- 返回值：如果有同阵营友武将，则返回 true，否则返回 false
-
-local function gongliGeneralAvailable(source, you_general_name_to_check)
-    if isGeneral(source, you_general_name_to_check) then
-        return true
-    end
-    for _, you_general in sgs.qlist(rinsan.getOtherPlayersWithGivenGeneralName(source, you_general_name_to_check)) do
-        if rinsan.isSameCamp(source, you_general) then
-            return true
-        end
-    end
-    return false
-end
-
 -- 玄剑选牌
 local function filterXuanjianCards(source, selected, to_select)
-    if gongliGeneralAvailable(source, YouZhugeliang_Name) then
+    if gongli.gongliSkillInvokable(source, YouXushu_Gongli_SkillName, YouZhugeliang_Name) then
         -- 共砺友诸葛亮生效：一张牌即可
         return #selected < 1 and not to_select:isEquipped()
     end
@@ -73,7 +55,7 @@ end
 
 -- 判断玄剑选牌合法性
 local function checkXuanjianCards(source, cards)
-    if gongliGeneralAvailable(source, YouZhugeliang_Name) then
+    if gongli.gongliSkillInvokable(source, YouXushu_Gongli_SkillName, YouZhugeliang_Name) then
         -- 共砺友诸葛亮生效：一张牌即可
         return #cards == 1 and not cards[1]:isEquipped()
     end
@@ -143,7 +125,7 @@ xuanjian_sword_limit_skill = sgs.CreateTargetModSkill {
     pattern = 'Slash',
     distance_limit_func = function(self, player, card)
         if card:getSkillName() == 'xuanjian_sword' then
-            if gongliGeneralAvailable(player, YouPangtong_Name) then
+            if gongli.gongliSkillInvokable(player, YouXushu_Gongli_SkillName, YouPangtong_Name) then
                 -- 共砺友庞统生效：无距离限制
                 return 1000
             end


### PR DESCRIPTION
## 拉取请求简述
提取共砺公共接口方法

统一提供调用方法

```lua
-- 总对外接口，是否可以发动共砺
-- source: 发动技能的武将
-- gongli_skill: 共砺技能名称
-- gongli_friend: 共砺友武将名称
-- 返回值：如果可以发动共砺，则返回 true，否则返回 false
function gongliSkillInvokable(source, gongli_skill, gongli_friend)
    -- 如果自身没有共砺技能，那必然不能发动
    if not source:hasSkill(gongli_skill) then
        return false
    end
    -- 如果本人即是友武将，即可发动
    if isYouGeneral(source, gongli_friend) then
        return true
    end
    -- 判断其他的同阵营友武将
    for _, you_general in sgs.qlist(rinsan.getOtherPlayersWithGivenGeneralName(source, gongli_friend)) do
        if rinsan.isSameCamp(source, you_general) then
            return true
        end
    end
    return false
end
```

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes # (issue)

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
