### PR TITLE
fix: 完善“侠行”获取【玄剑】时卡牌位置条件判断

### DIFF
--- a/extensions/OldFriendPackage.lua
+++ b/extensions/OldFriendPackage.lua
@@ -108,8 +108,8 @@ LuaXiaxing = sgs.CreateTriggerSkill {
             local drawPile = room:getDrawPile()
             newIds:append(xuanjian_id)
 
-            -- 若牌堆、弃牌堆、场上均不存在【玄剑】，此处不考虑场上已有的情况
-            -- 通常情况下此时不会有私家牌堆
+            -- 若牌堆、弃牌堆、场上均不存在【玄剑】
+            -- 新增判断私家牌堆
             local xuanjian_exists = false
             for _, id in sgs.qlist(drawPile) do
                 local cd = sgs.Sanguosha:getCard(id)
@@ -129,6 +129,20 @@ LuaXiaxing = sgs.CreateTriggerSkill {
                 for _, cd in sgs.qlist(p:getCards('hej')) do
                     if cd:objectName() == 'xuanjian_sword' then
                         xuanjian_exists = true
+                        break
+                    end
+                end
+
+                -- 检查玩家的私家牌堆
+                for _, pile in sgs.list(p:getPileNames()) do
+                    for _, cid in sgs.qlist(p:getPile(pile)) do
+                        local cd = sgs.Sanguosha:getCard(cid)
+                        if cd:objectName() == 'xuanjian_sword' then
+                            xuanjian_exists = true
+                            break
+                        end
+                    end
+                    if xuanjian_exists then
                         break
                     end
                 end


### PR DESCRIPTION
## 拉取请求简述
完善“侠行”获取【玄剑】时卡牌位置条件判断，追加弃牌堆、场上角色的区域以及私家牌堆检索

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

Fixes #1008 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
