### PR TITLE
fix: 修正壮誓错误的技能判断对象

### DIFF
--- a/extensions/CommonSkillPackage.lua
+++ b/extensions/CommonSkillPackage.lua
@@ -168,7 +168,7 @@ unresponsible = sgs.CreateTriggerSkill {
                 if not skillName then
                     return false
                 end
-                if rinsan.RIGHT(self, player, skillName) then
+                if rinsan.RIGHT(self, use.from, skillName) then
                     local jink_table = sgs.QList2Table(use.from:getTag('Jink_' .. use.card:toString()):toIntList())
                     local index = 1
                     for _, p in sgs.qlist(use.to) do

--- a/extensions/CommonSkillPackage.lua
+++ b/extensions/CommonSkillPackage.lua
@@ -139,6 +139,7 @@ unresponsible = sgs.CreateTriggerSkill {
                 return false
             end
             room:setTag('current_unresponsible_skill', sgs.QVariant(skillName))
+            local skillMark = string.format('%sTarget-%s', skillName, use.card:toString())
             room:setTag('current_unresponsible_skill_mark', sgs.QVariant(skillMark))
             for _, p in sgs.qlist(room:getAlivePlayers()) do
                 room:addPlayerMark(p, skillMark)
@@ -152,6 +153,10 @@ unresponsible = sgs.CreateTriggerSkill {
                 end
             end
         elseif event == sgs.CardAsked then
+            local skillName = room:getTag('current_unresponsible_skill'):toString()
+            if not skillName then
+                return false
+            end
             local skillMark = room:getTag('current_unresponsible_skill_mark'):toString()
             if not skillMark then
                 return false
@@ -162,7 +167,11 @@ unresponsible = sgs.CreateTriggerSkill {
                 return true
             end
         elseif event == sgs.TargetConfirmed then
+            -- TargetConfirmed 事件由 room:getAlivePlayers() 触发，player 为任意一名存活角色
             local use = data:toCardUse()
+            if not use.from or use.from:objectName() ~= player:objectName() then
+                return false
+            end
             if use.card:isKindOf('Slash') then
                 local skillName = room:getTag('current_unresponsible_skill'):toString()
                 if not skillName then
@@ -204,7 +213,7 @@ unresponsible = sgs.CreateTriggerSkill {
                 room:removePlayerMark(player, mark)
             end
             local skillName = room:getTag('current_unresponsible_skill'):toString()
-            local skillMark = room:getTag('current_unresponsible_skill_mark'):toString()
+            local skillMark = string.format('%sTarget-%s', skillName, use.card:toString())
             if not skillName then
                 return false
             end

--- a/extensions/CommonSkillPackage.lua
+++ b/extensions/CommonSkillPackage.lua
@@ -134,7 +134,7 @@ unresponsible = sgs.CreateTriggerSkill {
             if (not use.card) or use.card:isKindOf('SkillCard') then
                 return false
             end
-            local skillName, skillMark = get_skill_name(use.from)
+            local skillName, _ = get_skill_name(use.from)
             if not skillName then
                 return false
             end

--- a/extensions/CommonSkillPackage.lua
+++ b/extensions/CommonSkillPackage.lua
@@ -161,6 +161,15 @@ unresponsible = sgs.CreateTriggerSkill {
             if not skillMark then
                 return false
             end
+            local items = data:toStringList()[2]:split(':')
+            if #items > 1 then
+                local from = rinsan.findPlayerByName(room, items[2])
+                if not rinsan.RIGHT(self, from, skillName) then
+                    return false
+                end
+            else
+                return false
+            end
             if player:getMark(skillMark) > 0 then
                 room:provide(nil)
                 room:setPlayerMark(player, skillMark, 0)


### PR DESCRIPTION
## 拉取请求简述
修正壮誓错误的技能判断对象，当 player 与 use.from 不同的场景下，以 use.from 为准

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

1. Fixes #1028 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
