### PR TITLE
fix: 修正谋黄盖“诈降”后使用【借刀杀人】【杀】自己时无法闪避的问题

### DIFF
--- a/extensions/StrategicAttackShacklePackage.lua
+++ b/extensions/StrategicAttackShacklePackage.lua
@@ -233,8 +233,7 @@ LuaMouDuojing = sgs.CreateTriggerSkill {
                 room:doAnimate(rinsan.ANIMATE_INDICATE, player:objectName(), p:objectName())
                 room:addPlayerMark(player, self:objectName())
                 if not p:isNude() then
-                    local card_id =
-                        room:askForCardChosen(player, p, 'he', self:objectName(), false, sgs.Card_MethodNone)
+                    local card_id = room:askForCardChosen(player, p, 'he', self:objectName(), false, sgs.Card_MethodNone)
                     local reason = sgs.CardMoveReason(sgs.CardMoveReason_S_REASON_EXTRACTION, player:objectName())
                     room:obtainCard(player, sgs.Sanguosha:getCard(card_id), reason, false)
                 end
@@ -515,8 +514,7 @@ LuaDismantlement = sgs.CreateTrickCard {
     subtype = 'single_target_trick',
     filter = function(self, targets, to_select, player)
         local total_num = sgs.Sanguosha:correctCardTarget(sgs.TargetModSkill_ExtraTarget, player, self)
-        return
-            targets:length() < total_num and to_select ~= player:objectName() and to_select:getCards('hej'):length() > 0
+        return targets:length() < total_num and to_select ~= player:objectName() and to_select:getCards('hej'):length() > 0
     end,
     on_effect = function(self, effect)
         local source = effect.from
@@ -838,6 +836,15 @@ LuaMouZhaxiangBuff = sgs.CreateTriggerSkill {
                 end
             end
         elseif event == sgs.CardAsked then
+            local items = data:toStringList()[2]:split(':')
+            if #items > 1 then
+                local from = rinsan.findPlayerByName(room, items[2])
+                if not rinsan.RIGHT(self, from) then
+                    return false
+                end
+            else
+                return false
+            end
             if player:getMark('LuaMouZhaxiangTarget') > 0 then
                 room:provide(nil)
                 room:setPlayerMark(player, 'LuaMouZhaxiangTarget', 0)


### PR DESCRIPTION
## 拉取请求简述
修正谋黄盖“诈降”后使用【借刀杀人】【杀】自己时无法闪避的问题

### 处理议题内容
请在此部分添加处理的议题，以特殊词开头，例如 fix、resolve 等，注意数字后需要带空格，也可以通过 Github 自动补全完成这一步骤，如果没有，请删除本部分

1. Fixes #1030 

## 检查项目
在本部分，您需要在以下的列表进行确认操作，您或许会在确认的过程中回忆起来可以改进的内容

以下是示例，在下列括号内打勾仅需要在方框内输入小写x即可

- [x] 我已充分阅读并理解相关规范

### 代码部分
- [x] 我确认代码已经测试通过
- [x] 我已经充分注释了我的代码，尤其是难以理解的部分
- [x] 我已经检查了代码并修复了错误的拼写
- [x] 我的代码已经经历过项目要求的格式化
- [x] 我的代码不会引入警告

### 文档规范
- [x] 我已经在文档中进行了充分的修改
- [x] 我的拉取请求标题符合对应的格式
- [x] 我已经关联了必要的标签和议题
